### PR TITLE
리스트 아이템 하나 파싱할 때 발생하는 오류를 고친다

### DIFF
--- a/lib/autoblog/converter/parser/parser.rb
+++ b/lib/autoblog/converter/parser/parser.rb
@@ -5,7 +5,7 @@ require_relative 'parsers/parser_factory'
 class Parser
   def parse(tokens)
     body = body_parser.match(tokens)
-    raise "Syntax error: #{tokens[body.consumed]}" unless tokens.count == body.consumed
+    raise "Syntax error: tokens.count is not equal to body.consumed" unless tokens.count == body.consumed
     body
   end
 

--- a/lib/autoblog/converter/parser/parsers/list_item_and_newline_parser.rb
+++ b/lib/autoblog/converter/parser/parsers/list_item_and_newline_parser.rb
@@ -1,4 +1,4 @@
-require_relative "concerns/matches_star"
+require_relative "concerns/matches_first"
 
 class ListItemAndNewlineParser < BaseParser
   include MatchesFirst

--- a/lib/autoblog/converter/parser/parsers/list_item_and_newline_parser.rb
+++ b/lib/autoblog/converter/parser/parsers/list_item_and_newline_parser.rb
@@ -6,10 +6,9 @@ class ListItemAndNewlineParser < BaseParser
   def match(tokens)
     node = match_first tokens, list_item_parser
     return Node.null if node.null?
-    return Node.null unless tokens.peek_at(consumed, 'NEWLINE')
-    consumed += 1 # consume newlines
+    return Node.null unless tokens.peek_at(node.consumed, 'NEWLINE')
 
-    ParagraphNode.new(sentences: node, consumed: consumed)
+    ParagraphNode.new(sentences: node, consumed: node.consumed + 2)
   end
 end
 

--- a/lib/autoblog/converter/parser/parsers/list_item_and_newline_parser.rb
+++ b/lib/autoblog/converter/parser/parsers/list_item_and_newline_parser.rb
@@ -7,8 +7,10 @@ class ListItemAndNewlineParser < BaseParser
     node = match_first tokens, list_item_parser
     return Node.null if node.null?
     return Node.null unless tokens.peek_at(node.consumed, 'NEWLINE')
+    nodes, consumed = [node], node.consumed
+    consumed += 1
 
-    ParagraphNode.new(sentences: node, consumed: node.consumed + 2)
+    ParagraphNode.new(sentences: nodes, consumed: consumed)
   end
 end
 

--- a/lib/autoblog/converter/parser/parsers/paragraph_parser.rb
+++ b/lib/autoblog/converter/parser/parsers/paragraph_parser.rb
@@ -5,6 +5,6 @@ class ParagraphParser < BaseParser
   include MatchesFirst
 
   def match(tokens)
-    match_first tokens, list_item_and_newline_parser, sentences_and_newline_parser, sentences_and_eof_parser
+    match_first tokens, list_item_and_newline_parser, list_item_and_eof_parser, sentences_and_newline_parser, sentences_and_eof_parser
   end
 end

--- a/lib/autoblog/converter/parser/parsers/parser_factory.rb
+++ b/lib/autoblog/converter/parser/parsers/parser_factory.rb
@@ -9,6 +9,7 @@ require_relative "body_parser"
 require_relative "dash_parser"
 require_relative "list_item_parser"
 require_relative "list_item_and_newline_parser"
+require_relative "list_item_and_eof_parser"
 
 class ParserFactory
   PARSERS = {
@@ -22,7 +23,8 @@ class ParserFactory
     body_parser:                  BodyParser,
     dash_parser:                  DashParser,
     list_item_parser:             ListItemParser,
-    list_item_and_newline_parser: ListItemAndNewlineParser
+    list_item_and_newline_parser: ListItemAndNewlineParser,
+    list_item_and_eof_parser:     ListItemAndEofParser
   }.freeze
 
   def self.build(name, *args, &block)

--- a/lib/autoblog/converter/todo
+++ b/lib/autoblog/converter/todo
@@ -1,5 +1,9 @@
 list item 하나
  list item인 경우와 단순 sentence인 경우를 구분해 parsing할 수 있는지 확인하는 테스트 추가하기
+  기존 구현에 다소 문제가 있다
+  처음에 tokenize해서 나온 token의 갯수와 parse해서 얻은 node의 consumed 값이 같아야 한다
+  list item에선 text만 consumed에 포함하고 있는데, 이게 문제인 것 같다
+
  순서대로 - 기호, 빈 칸 하나 이상, 텍스트 하나 이상, newline char이 나와야 한다
   각각이 match_one, match_plus, match_plus, match_one 순으로 매칭되어야 한다
   이 순서대로 concern을 적용할 수 있나? <- 기존 코드에 이런 식으로 하고 있는 부분이 있나?

--- a/lib/autoblog/converter/todo
+++ b/lib/autoblog/converter/todo
@@ -1,18 +1,13 @@
-x dash
 list item 하나
- 어떤 예제로 테스트해야 할까?
+ list item인 경우와 단순 sentence인 경우를 구분해 parsing할 수 있는지 확인하는 테스트 추가하기
  순서대로 - 기호, 빈 칸 하나 이상, 텍스트 하나 이상, newline char이 나와야 한다
   각각이 match_one, match_plus, match_plus, match_one 순으로 매칭되어야 한다
   이 순서대로 concern을 적용할 수 있나? <- 기존 코드에 이런 식으로 하고 있는 부분이 있나?
  x match_plus 구현
  match_one 구현
- 기존 parser로는 구현이 어려워 보인다
-  token 추가해야 하나?
 동일한 위계의 list item 여러 개
 2단계 위계의 list 하나
 2단계 위계의 list 여러 개
-
-list item인 경우와 단순 sentence인 경우를 구분해 parsing할 수 있는지 확인하는 테스트 짜기
 
 matches_*의 반환값
  matches_first는 node만 반환하고 node, consumed 형태로 반환하지 않는다.
@@ -20,8 +15,19 @@ matches_*의 반환값
 concern_spec에서 describe MatchesStar 대신 describe Concern 쓰도록 모듈 구성 바꾸기
  MatchesStar, MatchesFirst 앞에 Concern:: 붙여야 한다
 
-find
- match_star 쓰는 곳에선 parser를 하나만 쓰는지 확인하기 위함
+nested list 문법은 어떤 형식이어야 하는가?
+ 앞이 newline
+ newline 이후로 별도의 space 없이 - 문자
+ - 문자 뒤에 하나 이상의 space 이후에 텍스트 시작
+ 끝이 newline
+ space* dash space+ text newline
+ 위와 같은 형식을 모두 모은 후에 nested list 여부를 판단하는 게 좋을까?
+dash 문자를 별도의 토큰으로 분류해야 하나?
+ 글 중간에 나오는 dash 문자는 리스트를 나타내는 토큰이 아니다
+ space* dash 형식인 경우에만 리스트용 dash 토큰으로 분류할 수 있을 것 같다
+
+match_star 쓰는 곳에선 parser를 하나만 쓰는지 확인하기
+ find를 쓰자
  lib 디렉토리 아래 모든 루비 파일에 대해
  find ./lib -type file -name "*.rb" |\
  match_star를 포함하는 줄을 검색하고, 그 내용을 출력한다

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -37,14 +37,12 @@ describe Parser do
     tokens = @tokenizer.tokenize("- foo\n\n")
     parser = ParserFactory.build(:list_item_and_newline_parser)
     nodes = parser.match(tokens)
-    expect(nodes.consumed).to eq 5
+    expect(nodes.consumed).to eq 4
   end
 
   it "parse 1 list item and newline" do
-    tokens = @tokenizer.tokenize("- foo\n\n")
-    p "TOKENS' COUNT: #{tokens.count}"
+    tokens = @tokenizer.tokenize("- foo\n")
     nodes = @parser.parse(tokens)
-    p "NODE'S VALUE: #{nodes.paragraphs}"
-    expect(nodes.consumed).to eq 5
+    expect(nodes.consumed).to eq 4
   end
 end

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -32,4 +32,19 @@ describe Parser do
     nodes = parser.match(tokens)
     expect(nodes.consumed).to eq 3
   end
+
+  it "list_item_and_newline_parser parse one list item and newline" do
+    tokens = @tokenizer.tokenize("- foo\n\n")
+    parser = ParserFactory.build(:list_item_and_newline_parser)
+    nodes = parser.match(tokens)
+    expect(nodes.consumed).to eq 5
+  end
+
+  it "parse 1 list item and newline" do
+    tokens = @tokenizer.tokenize("- foo\n\n")
+    p "TOKENS' COUNT: #{tokens.count}"
+    nodes = @parser.parse(tokens)
+    p "NODE'S VALUE: #{nodes.paragraphs}"
+    expect(nodes.consumed).to eq 5
+  end
 end

--- a/spec/token_list_spec.rb
+++ b/spec/token_list_spec.rb
@@ -43,6 +43,11 @@ describe TokenList do
     expect(token_list.peek_at(2, 'UNDERSCORE')).to eq true
   end
 
+  it "can put over 1 token to peek_at()" do
+    token_list = @tokens.tokenize('_Foo_')
+    expect(token_list.peek_at(1, 'TEXT', 'UNDERSCORE')).to eq true
+  end
+
   it "grab() picks tokens of smaller count than total token count" do
     token_list = @tokens.tokenize('_Foo_')
     grabbed = token_list.grab!(1) 


### PR DESCRIPTION
ParserFactory로 parser 종류를 직접 정한 경우 list item 파싱이 정상적으로 되었으나, 그렇지 않은 경우 테스트가 실패했다.

오류 원인을 알아보기 위해, 기존 markdown compiler 소스를 분석했다. 마크다운 형식 list item 하나를 토큰으로 만들고, 노드로 만드는 일련의 과정이 기존 형식과 맞는지 확인해보고자 했다.

- ParserFactory로 parser 종류를 직접 정하지 않는 이상, 모든 마크다운은 body 안의 paragraph로 분류된다.
  - list item:   tokenizer -> list item parser -> list item and newline parser -> paragraph parser -> body parser
  - sentence: tokenizer -> (...) -> sentence_parser -> sentences_and_xxx_parser ->paragraph parser -> body parser
- 각 parser는 matcher를 써서 반환값을 연산한다. 각 matcher는 어떤 형식의 데이터를 반환하나?
  - match_star: 매칭된 모든 노드를 가지는 리스트와 모든 노드 안 consumed값을 합친 consumed 값을 요소로 하는 리스트를 반환한다
  - match_first: 처음으로 매칭된 노드 하나를 반환한다
- senteces_and_xxx_parser는 어떤 형식의 데이터를 반환하나?
  - sentences_and_eof_parser: tokens의 마지막에 있는 newline과 eof는 반환할 nodes에 포함하지 않는다. 다만 consumed 값에는 두 값을 더한다
  - sentences_and_newline_parser: tokens의 마지막에 있는 newline 둘을 반환할 nodes에 포함하지 않는다. 다만 consumed 값에는 두 값을 더한다
- list_item_parser가 반환하는 형식은 문제가 없나?
  - 비슷한 역할을 하는 다른 파서인 bold_parser, emphasis_parser, text_parser를 확인해보면 1) value는 의미있는 값(즉 **xxx**에서 xxx, _xxx_에서 xxx와 같은)으로 설정하고 2)consumed는 의미있는 값과 포맷팅을 위한 값 모두를 센 값으로 설정한다(**xxx**는 * 네 개와 xxx라는 TEXT 토큰 하나이므로 총 5개)
- list item에서 토큰의 갯수가 consumed와 다르다.
  - sentences에선 왜 문제가 안되었을까? -> eof 토큰을 처리할 수 있는 sentence_and_eof_parser가 있기 때문이다.