### PR TITLE
메타 정보 관련 로직을 개선한다

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,7 @@ task :draft => [:clean_draft] do
   AutoBlog.process(
     File.join(File.dirname(__FILE__), *%w[source]),
     draft_dir,
-    "yes"
+    :draft
   )
 
   puts "you can check your drafts in #{draft_dir}"
@@ -28,7 +28,7 @@ task :publish => [:clean] do
   AutoBlog.process(
     File.join(File.dirname(__FILE__), *%w[source]),
     publish_dir,
-    "no"
+    :publish
   )
 
   puts "you can check your posts in #{publish_dir}"

--- a/lib/autoblog.rb
+++ b/lib/autoblog.rb
@@ -1,8 +1,8 @@
 require_relative 'autoblog/site'
 
 module AutoBlog
-  def self.process(source_path, dest_path, include_draft="no")
+  def self.process(source_path, dest_path, publish_type=:publish)
     s = Site.new(source_path)
-    s.process(dest_path, include_draft)
+    s.process(dest_path, publish_type)
   end
 end

--- a/lib/autoblog/logging.rb
+++ b/lib/autoblog/logging.rb
@@ -1,0 +1,15 @@
+module AutoBlog
+  module Logging
+    def logger
+      Logging.logger
+    end
+
+    def self.logger
+      @logger ||= Logger.new($stderr)
+    end
+
+    def self.redirect_output(io)
+      logger.reopen(io)
+    end
+  end
+end

--- a/lib/autoblog/meta_info.rb
+++ b/lib/autoblog/meta_info.rb
@@ -28,5 +28,28 @@ module AutoBlog
     def find_meta_info key
       @hash[key]
     end
+
+    def make_meta_info(post)
+      msg = ""
+      required_keys = ["title", "published_at", "draft"]
+
+      if required_keys.any? {|key| @hash[key].nil?}
+        msg << "#{post.src_path}\n  required field not provided:"
+        required_keys.each do |key|
+          msg << " #{key}," if @hash[key].nil?
+        end
+        msg.sub!(/,$/, "")
+        msg << "\n  trying to set default value for the fields..."
+        msg << "\n  but you need to write in the markdown source file"
+      end
+
+      today = Date.today.to_s.gsub("-", "/")
+      title, published_at, draft, msg = [
+        @hash["title"] || post.nm,
+        @hash["published_at"] || today,
+        @hash["draft"],
+        msg
+      ]
+    end
   end
 end

--- a/lib/autoblog/meta_info.rb
+++ b/lib/autoblog/meta_info.rb
@@ -2,12 +2,14 @@ module AutoBlog
   class MetaInfo
     END_SIGN = /^\*\*\*meta-info-ends\*\*\*/
 
+    attr_reader :hash
+
     def initialize(file)
-      @file = file
+      @hash = read_meta_info(file)
     end
 
-    def read_meta_info
-      lines = @file.split("\n")
+    def read_meta_info(file)
+      lines = file.split("\n")
       meta_info_ends = lines.find_index {|l| l =~ END_SIGN}
       if meta_info_ends.nil?
         meta_info = {"draft" => "yes"}

--- a/lib/autoblog/meta_info.rb
+++ b/lib/autoblog/meta_info.rb
@@ -1,5 +1,9 @@
+require_relative 'logging'
+
 module AutoBlog
   class MetaInfo
+    include Logging
+
     END_SIGN = /^\*\*\*meta-info-ends\*\*\*/
 
     attr_reader :hash
@@ -34,21 +38,23 @@ module AutoBlog
       required_keys = ["title", "published_at", "draft"]
 
       if required_keys.any? {|key| @hash[key].nil?}
-        msg << "#{post.src_path}\n  required field not provided:"
+        msg << "\nrequired field not provided:"
         required_keys.each do |key|
           msg << " #{key}," if @hash[key].nil?
         end
         msg.sub!(/,$/, "")
-        msg << "\n  trying to set default value for the fields..."
-        msg << "\n  but you need to write in the markdown source file"
+        msg << "\n  in #{post.src_path}"
+        msg << "\n  set default value for the fields"
+        msg << "\n  but you need to write values in the source file"
+
+        logger.warn(msg)
       end
 
       today = Date.today.to_s.gsub("-", "/")
-      title, published_at, draft, msg = [
+      title, published_at, draft = [
         @hash["title"] || post.nm,
         @hash["published_at"] || today,
-        @hash["draft"],
-        msg
+        @hash["draft"]
       ]
     end
   end

--- a/lib/autoblog/meta_info.rb
+++ b/lib/autoblog/meta_info.rb
@@ -24,5 +24,9 @@ module AutoBlog
       end
       meta_info
     end
+
+    def find_meta_info key
+      @hash[key]
+    end
   end
 end

--- a/lib/autoblog/meta_info.rb
+++ b/lib/autoblog/meta_info.rb
@@ -2,14 +2,12 @@ module AutoBlog
   class MetaInfo
     END_SIGN = /^\*\*\*meta-info-ends\*\*\*/
 
-    def initialize(path, file)
-      @path = path
+    def initialize(file)
       @file = file
     end
 
-    def read_meta_info(path, file)
-      file_content = File.read(File.join(path, file)).strip
-      lines = file_content.split("\n")
+    def read_meta_info
+      lines = @file.split("\n")
       meta_info_ends = lines.find_index {|l| l =~ END_SIGN}
       if meta_info_ends.nil?
         meta_info = {"draft" => "yes"}

--- a/lib/autoblog/meta_info.rb
+++ b/lib/autoblog/meta_info.rb
@@ -1,0 +1,28 @@
+module AutoBlog
+  class MetaInfo
+    END_SIGN = /^\*\*\*meta-info-ends\*\*\*/
+
+    def initialize(path, file)
+      @path = path
+      @file = file
+    end
+
+    def read_meta_info(path, file)
+      file_content = File.read(File.join(path, file)).strip
+      lines = file_content.split("\n")
+      meta_info_ends = lines.find_index {|l| l =~ END_SIGN}
+      if meta_info_ends.nil?
+        meta_info = {"draft" => "yes"}
+        return meta_info
+      end
+
+      meta_info = {}
+      lines[0, meta_info_ends].each do |info|
+        key = info.split(":")[0].strip
+        value = info.split(":")[1].strip
+        meta_info[key] = value ||= "EMPTY"
+      end
+      meta_info
+    end
+  end
+end

--- a/lib/autoblog/post.rb
+++ b/lib/autoblog/post.rb
@@ -35,11 +35,11 @@ module AutoBlog
 
     def read_meta_info(path, file)
       file_content = File.read(File.join(path, file)).strip
-      MetaInfo.new(file_content).read_meta_info
+      MetaInfo.new(file_content)
     end
 
     def find_meta_info key
-      @meta_info[key]
+      @meta_info.hash[key]
     end
 
     def make_url(ext="html")

--- a/lib/autoblog/post.rb
+++ b/lib/autoblog/post.rb
@@ -34,7 +34,8 @@ module AutoBlog
     end
 
     def read_meta_info(path, file)
-      MetaInfo.new(path, file).read_meta_info(path, file)
+      file_content = File.read(File.join(path, file)).strip
+      MetaInfo.new(file_content).read_meta_info
     end
 
     def find_meta_info key

--- a/lib/autoblog/post.rb
+++ b/lib/autoblog/post.rb
@@ -1,5 +1,6 @@
 require 'md2html'
 require 'erb'
+require_relative 'meta_info'
 
 module AutoBlog
   class Post

--- a/lib/autoblog/post.rb
+++ b/lib/autoblog/post.rb
@@ -4,9 +4,10 @@ require_relative 'meta_info'
 
 module AutoBlog
   class Post
-    attr_reader :nm, :source, :meta_info, :url
+    attr_reader :src_path, :nm, :source, :meta_info, :url
 
     def initialize(path, file)
+      @src_path = File.join(path, file)
       @nm = file.split(".").first
       @source = read_source(path, file)
       @meta_info = read_meta_info(path, file)
@@ -39,8 +40,12 @@ module AutoBlog
       MetaInfo.new(file_content)
     end
 
-    def find_meta_info(key)
-      @meta_info.find_meta_info(key)
+    def make_meta_info
+      @meta_info.make_meta_info(self)
+    end
+
+    def is_draft?
+      @meta_info.find_meta_info("draft") == "yes"
     end
 
     def make_url(ext="html")

--- a/lib/autoblog/post.rb
+++ b/lib/autoblog/post.rb
@@ -38,8 +38,8 @@ module AutoBlog
       MetaInfo.new(file_content)
     end
 
-    def find_meta_info key
-      @meta_info.hash[key]
+    def find_meta_info(key)
+      @meta_info.find_meta_info(key)
     end
 
     def make_url(ext="html")

--- a/lib/autoblog/post.rb
+++ b/lib/autoblog/post.rb
@@ -2,8 +2,6 @@ require 'md2html'
 require 'erb'
 
 module AutoBlog
-  META_INFO_REGEX = /^\*\*\*meta-info-ends\*\*\*/
-
   class Post
     attr_reader :nm, :source, :meta_info, :url
 
@@ -24,16 +22,10 @@ module AutoBlog
       dest_path
     end
 
-    def read_file(path, file)
-      File.read(
-        File.join(path, file)
-      ).strip
-    end
-
     def read_source(path, file)
-      file_content = read_file(path, file)
+      file_content = File.read(File.join(path, file)).strip
       lines = file_content.split("\n")
-      src_starts = lines.find_index {|l| l =~ META_INFO_REGEX}
+      src_starts = lines.find_index {|l| l =~ MetaInfo::END_SIGN}
       if src_starts != nil
         return lines[src_starts+1..-1].join("\n")
       else
@@ -42,21 +34,7 @@ module AutoBlog
     end
 
     def read_meta_info(path, file)
-      file_content = read_file(path, file)
-      lines = file_content.split("\n")
-      meta_info_ends = lines.find_index {|l| l =~ META_INFO_REGEX}
-      if meta_info_ends.nil?
-        meta_info = {"draft" => "yes"}
-        return meta_info
-      end
-
-      meta_info = {}
-      lines[0, meta_info_ends].each do |info|
-        key = info.split(":")[0].strip
-        value = info.split(":")[1].strip
-        meta_info[key] = value ||= "EMPTY"
-      end
-      meta_info
+      MetaInfo.new(path, file).read_meta_info(path, file)
     end
 
     def find_meta_info key

--- a/lib/autoblog/site.rb
+++ b/lib/autoblog/site.rb
@@ -14,9 +14,9 @@ module AutoBlog
       end
     end
 
-    def process dest_path, include_draft="no"
+    def process dest_path, publish_type
       posts2proc = @posts
-      if include_draft == "no"
+      if publish_type == :publish
         posts2proc = posts2proc
                        .select {|p| p.find_meta_info("draft") == "no"}
       end
@@ -25,12 +25,12 @@ module AutoBlog
         .each do |post|
         post.write(dest_path)
       end
-      write_index dest_path, include_draft
+      write_index dest_path, publish_type
       copy_static_info dest_path
     end
 
-    def write_index path, include_draft
-      content = make_index_content path, include_draft
+    def write_index path, publish_type
+      content = make_index_content path, publish_type
 
       template_path = File.join(File.dirname(__FILE__), *%w[.. layout index.html])
       stylesheet_path = File.join(File.dirname(__FILE__), *%w[.. css index.css])
@@ -47,11 +47,11 @@ module AutoBlog
       path
     end
 
-    def make_index_content path, include_draft
+    def make_index_content path, publish_type
       content = "<ul>"
 
       posts2proc = @posts
-      if include_draft == "no"
+      if publish_type == :publish
         posts2proc = posts2proc
                        .select {|p| p.find_meta_info("draft") == "no"}
       end

--- a/lib/autoblog/site.rb
+++ b/lib/autoblog/site.rb
@@ -60,7 +60,7 @@ module AutoBlog
       posts2proc
         .each do |post|
         if post.meta_info != nil
-          title, published_at, ignore, msg = post.make_meta_info
+          title, published_at, ignore = post.make_meta_info
         end
 
         content.concat("<li>

--- a/lib/autoblog/site.rb
+++ b/lib/autoblog/site.rb
@@ -1,5 +1,6 @@
 require_relative 'post'
 require 'fileutils'
+require 'date'
 
 module AutoBlog
   class Site
@@ -18,7 +19,7 @@ module AutoBlog
       posts2proc = @posts
       if publish_type == :publish
         posts2proc = posts2proc
-                       .select {|p| p.find_meta_info("draft") == "no"}
+                       .select {|p| p.is_draft? == false}
       end
 
       posts2proc
@@ -53,14 +54,13 @@ module AutoBlog
       posts2proc = @posts
       if publish_type == :publish
         posts2proc = posts2proc
-                       .select {|p| p.find_meta_info("draft") == "no"}
+                       .select {|p| p.is_draft? == false}
       end
 
       posts2proc
         .each do |post|
         if post.meta_info != nil
-          title = post.find_meta_info("title") || post.nm
-          published_at = post.find_meta_info("published_at") || ""
+          title, published_at, ignore, msg = post.make_meta_info
         end
 
         content.concat("<li>

--- a/spec/helpers/spec_helper.rb
+++ b/spec/helpers/spec_helper.rb
@@ -14,9 +14,20 @@
 #
 # See https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 require_relative './file_helper'
+require_relative '../../lib/autoblog/logging'
 
 RSpec.configure do |config|
   config.include FileHelper
+
+  RSpec.configure do |config|
+    config.before(:suite) do
+      AutoBlog::Logging.redirect_output(File.open(File::NULL, 'w'))
+    end
+
+    config.after(:suite) do
+      AutoBlog::Logging.redirect_output($stderr)
+    end
+  end
 
   RSpec.configure do |config|
     config.filter_run_when_matching(focus: true)

--- a/spec/meta_info_spec.rb
+++ b/spec/meta_info_spec.rb
@@ -5,8 +5,9 @@ describe AutoBlog::MetaInfo, "meta info 객체는" do
   it "인덱스 파일에 제공할 정보를 따로 저장한다" do
     file_path = File.join(File.dirname(__FILE__), *%w[source])
     file_nm = 'has_meta_info.md'
+    file_content = File.read(File.join(file_path, file_nm)).strip
 
-    meta_info = AutoBlog::MetaInfo.new(file_path, file_nm).read_meta_info(file_path, file_nm)
+    meta_info = AutoBlog::MetaInfo.new(file_content).read_meta_info
     meta_info.keys.each {|key|
       expect(meta_info[key]).not_to be_empty
     }
@@ -15,8 +16,9 @@ describe AutoBlog::MetaInfo, "meta info 객체는" do
   it "처음 만드는 블로그 글은 초안이다" do
     file_path = File.join(File.dirname(__FILE__), *%w[source])
     file_nm = 'draft_post.md'
+    file_content = File.read(File.join(file_path, file_nm)).strip
 
-    meta_info = AutoBlog::MetaInfo.new(file_path, file_nm).read_meta_info(file_path, file_nm)
+    meta_info = AutoBlog::MetaInfo.new(file_content).read_meta_info
     expect(meta_info['draft']).to eq('yes')
   end
 end

--- a/spec/meta_info_spec.rb
+++ b/spec/meta_info_spec.rb
@@ -7,7 +7,7 @@ describe AutoBlog::MetaInfo, "meta info 객체는" do
     file_nm = 'has_meta_info.md'
     file_content = File.read(File.join(file_path, file_nm)).strip
 
-    meta_info = AutoBlog::MetaInfo.new(file_content).read_meta_info
+    meta_info = AutoBlog::MetaInfo.new(file_content).hash
     meta_info.keys.each {|key|
       expect(meta_info[key]).not_to be_empty
     }
@@ -18,7 +18,7 @@ describe AutoBlog::MetaInfo, "meta info 객체는" do
     file_nm = 'draft_post.md'
     file_content = File.read(File.join(file_path, file_nm)).strip
 
-    meta_info = AutoBlog::MetaInfo.new(file_content).read_meta_info
+    meta_info = AutoBlog::MetaInfo.new(file_content).hash
     expect(meta_info['draft']).to eq('yes')
   end
 end

--- a/spec/meta_info_spec.rb
+++ b/spec/meta_info_spec.rb
@@ -1,0 +1,22 @@
+require_relative '../lib/autoblog/meta_info'
+require 'helpers/spec_helper'
+
+describe AutoBlog::MetaInfo, "meta info 객체는" do
+  it "인덱스 파일에 제공할 정보를 따로 저장한다" do
+    file_path = File.join(File.dirname(__FILE__), *%w[source])
+    file_nm = 'has_meta_info.md'
+
+    meta_info = AutoBlog::MetaInfo.new(file_path, file_nm).read_meta_info(file_path, file_nm)
+    meta_info.keys.each {|key|
+      expect(meta_info[key]).not_to be_empty
+    }
+  end
+
+  it "처음 만드는 블로그 글은 초안이다" do
+    file_path = File.join(File.dirname(__FILE__), *%w[source])
+    file_nm = 'draft_post.md'
+
+    meta_info = AutoBlog::MetaInfo.new(file_path, file_nm).read_meta_info(file_path, file_nm)
+    expect(meta_info['draft']).to eq('yes')
+  end
+end

--- a/spec/post_spec.rb
+++ b/spec/post_spec.rb
@@ -36,24 +36,4 @@ describe AutoBlog::Post, "post 객체는" do
     p = AutoBlog::Post.new(file_path, file_nm)
     expect(p.source).not_to include("***meta-info-ends***")
   end
-
-  it "인덱스 파일에 제공할 정보를 따로 저장한다" do
-    file_path = File.join(File.dirname(__FILE__), *%w[source])
-    file_nm = 'has_meta_info.md'
-
-    p = AutoBlog::Post.new(file_path, file_nm)
-    meta_info = p.read_meta_info(file_path, file_nm)
-    meta_info.hash.keys.each {|key|
-      expect(meta_info.hash[key]).not_to be_empty
-    }
-  end
-
-  it "처음 만드는 블로그 글은 초안이다" do
-    file_path = File.join(File.dirname(__FILE__), *%w[source])
-    file_nm = 'draft_post.md'
-
-    p = AutoBlog::Post.new(file_path, file_nm)
-    meta_info = p.read_meta_info(file_path, file_nm)
-    expect(meta_info.hash['draft']).to eq('yes')
-  end
 end

--- a/spec/post_spec.rb
+++ b/spec/post_spec.rb
@@ -43,8 +43,8 @@ describe AutoBlog::Post, "post 객체는" do
 
     p = AutoBlog::Post.new(file_path, file_nm)
     meta_info = p.read_meta_info(file_path, file_nm)
-    meta_info.keys.each {|key|
-      expect(meta_info[key]).not_to be_empty
+    meta_info.hash.keys.each {|key|
+      expect(meta_info.hash[key]).not_to be_empty
     }
   end
 
@@ -54,6 +54,6 @@ describe AutoBlog::Post, "post 객체는" do
 
     p = AutoBlog::Post.new(file_path, file_nm)
     meta_info = p.read_meta_info(file_path, file_nm)
-    expect(meta_info['draft']).to eq('yes')
+    expect(meta_info.hash['draft']).to eq('yes')
   end
 end

--- a/spec/site_spec.rb
+++ b/spec/site_spec.rb
@@ -14,7 +14,7 @@ describe AutoBlog::Site do
 
   it "html 파일을 만들어 dest 디렉토리에 저장한다" do
     dest_dir = File.join(File.dirname(__FILE__), *%w[dest])
-    @site.process(dest_dir)
+    @site.process(dest_dir, :publish)
     clean_up(dest_dir)
   end
 

--- a/spec/site_spec.rb
+++ b/spec/site_spec.rb
@@ -36,9 +36,18 @@ describe AutoBlog::Site do
   it "인덱스 페이지 관련 정보를 post 객체로부터 가져올 수 있다" do
     meta_info = @site.posts.select {|p|
       p.url == "./has_meta_info.html"
-    }[0].find_meta_info("title")
+    }[0].make_meta_info
 
-    expect(meta_info).to eq("xxx")
+    expect(meta_info[0..2]).to eq(["xxx", "2024/07/19", "no"])
+  end
+
+  it "인덱스 페이지 관련 정보 중 필수값이 없는 경우를 처리할 수 있다" do
+    meta_info = @site.posts.select {|p|
+      p.url == "./draft_post.html"
+    }[0].make_meta_info
+
+    expect(meta_info[0..2]).to eq(["draft_post", Date.today.to_s.gsub("-", "/"), "yes"])
+    expect(meta_info[3]).not_to be(nil)
   end
 
   it "publish할 때는 초안 블로그 글을 제외할 수 있다" do

--- a/spec/site_spec.rb
+++ b/spec/site_spec.rb
@@ -38,7 +38,7 @@ describe AutoBlog::Site do
       p.url == "./has_meta_info.html"
     }[0].make_meta_info
 
-    expect(meta_info[0..2]).to eq(["xxx", "2024/07/19", "no"])
+    expect(meta_info).to eq(["xxx", "2024/07/19", "no"])
   end
 
   it "인덱스 페이지 관련 정보 중 필수값이 없는 경우를 처리할 수 있다" do
@@ -46,8 +46,7 @@ describe AutoBlog::Site do
       p.url == "./draft_post.html"
     }[0].make_meta_info
 
-    expect(meta_info[0..2]).to eq(["draft_post", Date.today.to_s.gsub("-", "/"), "yes"])
-    expect(meta_info[3]).not_to be(nil)
+    expect(meta_info).to eq(["draft_post", Date.today.to_s.gsub("-", "/"), "yes"])
   end
 
   it "publish할 때는 초안 블로그 글을 제외할 수 있다" do


### PR DESCRIPTION
- post 객체에서 처리하던 meta_info 관련 로직을 별도의 클래스로 떼어낸다
- meta_info와 관련된 정보는 자신만 알고 있도록 가능한 meta_info 객체로 밀어넣는다
- meta_info 필수 필드 미입력 상황이 발생한 경우, 사용자가 블로그 빌드 시 알 수 있도록 로그 기능을 구현한다