### PR TITLE
블로그 소스에 이미지 파일을 추가할 수 있다

### DIFF
--- a/lib/autoblog/site.rb
+++ b/lib/autoblog/site.rb
@@ -84,6 +84,12 @@ module AutoBlog
         File.join(File.dirname(__FILE__), *%w[.. .. lib fonts/.]),
         File.join(dest_path, *%w[fonts])
       )
+
+      FileUtils.mkdir_p(File.join(dest_path, *%w[images]))
+      FileUtils.cp_r(
+        File.join(File.dirname(__FILE__), *%w[.. .. source images/.]),
+        File.join(dest_path, *%w[images])
+      )
     end
   end
 end

--- a/lib/css/main.css
+++ b/lib/css/main.css
@@ -37,6 +37,11 @@ p {
   margin: 1em 0;
 }
 
+div img {
+  max-width: 100%;
+  max-height: 100%;
+}
+
 a {
   color: #00a;
 }


### PR DESCRIPTION
- source/images 디렉토리에 넣은 이미지 파일을 블로그 빌드 결과에 포함한다
- img 태그 요소의 사이즈를 설정한다