### PR TITLE
인덱스 페이지의 글 순서를 최신 날짜가 먼저 나오게 정렬한다

### DIFF
--- a/lib/autoblog/meta_info.rb
+++ b/lib/autoblog/meta_info.rb
@@ -37,7 +37,9 @@ module AutoBlog
       @hash[key]
     end
 
-    def make_meta_info(post)
+    def make_meta_info(post_info = {})
+      post_nm = post_info[:nm]
+      src_path = post_info[:src_path]
       msg = ""
       required_keys = ["title", "published_at", "draft"]
 
@@ -47,7 +49,7 @@ module AutoBlog
           msg << " #{key}," if @hash[key].nil?
         end
         msg.sub!(/,$/, "")
-        msg << "\n  in #{post.src_path}"
+        msg << "\n  in #{src_path}"
         msg << "\n  set default value for the fields"
         msg << "\n  but you need to write values in the source file"
 
@@ -56,7 +58,7 @@ module AutoBlog
 
       today = Date.today.to_s.gsub("-", "/")
       title, published_at, draft = [
-        @hash["title"] || post.nm,
+        @hash["title"] || post_nm,
         @hash["published_at"] || today,
         @hash["draft"]
       ]

--- a/lib/autoblog/meta_info.rb
+++ b/lib/autoblog/meta_info.rb
@@ -1,19 +1,18 @@
 require_relative 'logging'
 
 module AutoBlog
-  class MetaInfo
+  class MetaInfo < Hash
     include Logging
 
     END_SIGN = /^\*\*\*meta-info-ends\*\*\*/
 
-    attr_reader :hash
-
     def initialize(hash)
-      @hash = hash
+      super()
+      self.merge!(hash)
     end
 
     def self.from_file(file_content)
-      self.new(self.read_meta_info(file_content))
+      self.read_meta_info(file_content)
     end
 
     def self.read_meta_info(file)
@@ -30,11 +29,12 @@ module AutoBlog
         value = info.split(":")[1].strip
         meta_info[key] = value || nil
       end
-      meta_info
+
+      self.new(meta_info).make_meta_info
     end
 
     def find_meta_info key
-      @hash[key]
+      self[key]
     end
 
     def make_meta_info(post_info = {})
@@ -43,10 +43,10 @@ module AutoBlog
       msg = ""
       required_keys = ["title", "published_at", "draft"]
 
-      if required_keys.any? {|key| @hash[key].nil?}
+      if required_keys.any? {|key| self[key].nil?}
         msg << "\nrequired field not provided:"
         required_keys.each do |key|
-          msg << " #{key}," if @hash[key].nil?
+          msg << " #{key}," if self[key].nil?
         end
         msg.sub!(/,$/, "")
         msg << "\n  in #{src_path}"
@@ -57,11 +57,11 @@ module AutoBlog
       end
 
       today = Date.today.to_s.gsub("-", "/")
-      title, published_at, draft = [
-        @hash["title"] || post_nm,
-        @hash["published_at"] || today,
-        @hash["draft"]
-      ]
+      self.merge({
+        "title" => self["title"] || post_nm,
+        "published_at" => self["published_at"] || today,
+        "draft" => self["draft"] || "yes"
+      })
     end
   end
 end

--- a/lib/autoblog/meta_info.rb
+++ b/lib/autoblog/meta_info.rb
@@ -8,11 +8,15 @@ module AutoBlog
 
     attr_reader :hash
 
-    def initialize(file)
-      @hash = read_meta_info(file)
+    def initialize(hash)
+      @hash = hash
     end
 
-    def read_meta_info(file)
+    def self.from_file(file_content)
+      self.new(self.read_meta_info(file_content))
+    end
+
+    def self.read_meta_info(file)
       lines = file.split("\n")
       meta_info_ends = lines.find_index {|l| l =~ END_SIGN}
       if meta_info_ends.nil?

--- a/lib/autoblog/meta_info.rb
+++ b/lib/autoblog/meta_info.rb
@@ -24,7 +24,7 @@ module AutoBlog
       lines[0, meta_info_ends].each do |info|
         key = info.split(":")[0].strip
         value = info.split(":")[1].strip
-        meta_info[key] = value ||= "EMPTY"
+        meta_info[key] = value || nil
       end
       meta_info
     end

--- a/lib/autoblog/meta_info.rb
+++ b/lib/autoblog/meta_info.rb
@@ -19,8 +19,8 @@ module AutoBlog
       lines = file.split("\n")
       meta_info_ends = lines.find_index {|l| l =~ END_SIGN}
       if meta_info_ends.nil?
-        meta_info = {"draft" => "yes"}
-        return meta_info
+        meta_info = {}
+        return self.new(meta_info).make_meta_info
       end
 
       meta_info = {}

--- a/lib/autoblog/post.rb
+++ b/lib/autoblog/post.rb
@@ -37,7 +37,7 @@ module AutoBlog
 
     def read_meta_info(path, file)
       file_content = File.read(File.join(path, file)).strip
-      MetaInfo.new(file_content)
+      MetaInfo::from_file(file_content)
     end
 
     def make_meta_info

--- a/lib/autoblog/post.rb
+++ b/lib/autoblog/post.rb
@@ -41,7 +41,12 @@ module AutoBlog
     end
 
     def make_meta_info
-      @meta_info.make_meta_info(self)
+      @meta_info.make_meta_info(
+        post_info={
+          :nm => self.nm,
+          :src_path => self.src_path
+        }
+      )
     end
 
     def is_draft?

--- a/lib/autoblog/site.rb
+++ b/lib/autoblog/site.rb
@@ -60,7 +60,8 @@ module AutoBlog
       posts2proc
         .each do |post|
         if post.meta_info != nil
-          title, published_at, ignore = post.make_meta_info
+          meta_info = post.make_meta_info
+          title, published_at, ignore = meta_info["title"], meta_info["published_at"], meta_info["draft"]
         end
 
         content.concat("<li>

--- a/lib/autoblog/site.rb
+++ b/lib/autoblog/site.rb
@@ -56,6 +56,8 @@ module AutoBlog
         posts2proc = posts2proc
                        .select {|p| p.is_draft? == false}
       end
+      posts2proc.sort_by! {|p| p.meta_info["published_at"]}
+                .reverse!
 
       posts2proc
         .each do |post|

--- a/spec/meta_info_spec.rb
+++ b/spec/meta_info_spec.rb
@@ -7,7 +7,7 @@ describe AutoBlog::MetaInfo, "meta info 객체는" do
     file_nm = 'has_meta_info.md'
     file_content = File.read(File.join(file_path, file_nm)).strip
 
-    meta_info = AutoBlog::MetaInfo.new(file_content).hash
+    meta_info = AutoBlog::MetaInfo::from_file(file_content).hash
     meta_info.keys.each {|key|
       expect(meta_info[key]).not_to be_empty
     }
@@ -18,7 +18,7 @@ describe AutoBlog::MetaInfo, "meta info 객체는" do
     file_nm = 'draft_post.md'
     file_content = File.read(File.join(file_path, file_nm)).strip
 
-    meta_info = AutoBlog::MetaInfo.new(file_content).hash
+    meta_info = AutoBlog::MetaInfo::from_file(file_content).hash
     expect(meta_info['draft']).to eq('yes')
   end
 end

--- a/spec/meta_info_spec.rb
+++ b/spec/meta_info_spec.rb
@@ -7,7 +7,7 @@ describe AutoBlog::MetaInfo, "meta info 객체는" do
     file_nm = 'has_meta_info.md'
     file_content = File.read(File.join(file_path, file_nm)).strip
 
-    meta_info = AutoBlog::MetaInfo::from_file(file_content).hash
+    meta_info = AutoBlog::MetaInfo::from_file(file_content)
     meta_info.keys.each {|key|
       expect(meta_info[key]).not_to be_empty
     }
@@ -18,7 +18,7 @@ describe AutoBlog::MetaInfo, "meta info 객체는" do
     file_nm = 'draft_post.md'
     file_content = File.read(File.join(file_path, file_nm)).strip
 
-    meta_info = AutoBlog::MetaInfo::from_file(file_content).hash
+    meta_info = AutoBlog::MetaInfo::from_file(file_content)
     expect(meta_info['draft']).to eq('yes')
   end
 end

--- a/spec/site_spec.rb
+++ b/spec/site_spec.rb
@@ -38,7 +38,13 @@ describe AutoBlog::Site do
       p.url == "./has_meta_info.html"
     }[0].make_meta_info
 
-    expect(meta_info).to eq(["xxx", "2024/07/19", "no"])
+    expect(meta_info).to eq(
+      {
+        "title" => "xxx",
+        "published_at" => "2024/07/19",
+        "draft" => "no"
+      }
+    )
   end
 
   it "인덱스 페이지 관련 정보 중 필수값이 없는 경우를 처리할 수 있다" do
@@ -46,7 +52,13 @@ describe AutoBlog::Site do
       p.url == "./draft_post.html"
     }[0].make_meta_info
 
-    expect(meta_info).to eq(["draft_post", Date.today.to_s.gsub("-", "/"), "yes"])
+    expect(meta_info).to eq(
+      {
+        "title" => "draft_post",
+        "published_at" => Date.today.to_s.gsub("-", "/"),
+        "draft" => "yes"
+      }
+    )
   end
 
   it "publish할 때는 초안 블로그 글을 제외할 수 있다" do


### PR DESCRIPTION
인덱스 페이지의 글 목록을 만들 때, 날짜 순으로 글 순서를 바꾸려면 post의 meta_info에 published_at이 설정되어 있어야 한다.
하지만 기존 meta_info 생성 로직이 위 변경사항을 쉽게 적용할만큼 유연하지 않아서, 다음과 같이 구조를 개선했다.

1) meta_info 인스턴스를 초기화할 때, 파일 내용뿐 아니라 Hash 값으로도 초기화할 수 있도록 한다
2) meta_info.make_meta_info 로직은 post를 인자로 받고 있었지만, post의 모든 정보가 필요한 건 아니다. 필요한 정보만 미리 연산해서 make_meta_info 메서드에 인자로 건네도록 바꾼다
3) meta_info.make_meta_info 로직은 Hash 인스턴스를 반환하고 있었기 때문에, MetaInfo 클래스에서 정의한 메서드를 바로 호출하기 어려웠다. MetaInfo 클래스가 Hash 클래스를 상속하도록 해서 메서드를 바로 호출할 수 있도록 바꿨다
4) meta_info.read_meta_info의 몸체에서 meta_info_ends.nil?이 true인 경우, mata_info에 published_at 필드가 설정되지 않아 인덱스 페이지 정렬에 실패한다. 이 때도 published_at 필드가 설정되도록 로직을 수정했다